### PR TITLE
fix(ledger): enable "rt" tokio feature

### DIFF
--- a/bip39/Cargo.toml
+++ b/bip39/Cargo.toml
@@ -22,7 +22,7 @@ sha2 = "0.10"
 thiserror = "1.0"
 
 # used by all wordlists
-once_cell = { version = "1.17", optional = true }
+once_cell = { version = "1.18", optional = true }
 
 [dev-dependencies]
 hex = "0.4"

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -27,12 +27,12 @@ thiserror = "1.0"
 # native
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 lazy_static = "1.4"
-byteorder = "1.4"
+byteorder = "1.5"
 libc = "0.2"
 matches = "0.1"
 tracing = "0.1"
 hidapi-rusb = "1.3"
-tokio = { version = "1.28", features = ["sync"] }
+tokio = { version = "1.34", features = ["sync", "rt"] }
 
 # linux native only
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -40,15 +40,15 @@ nix = "0.26"
 
 # WASM
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = "0.2.86"
-wasm-bindgen-futures = "0.4.36"
-js-sys = "0.3.63"
+wasm-bindgen = "0.2.88"
+wasm-bindgen-futures = "0.4.38"
+js-sys = "0.3.65"
 log = "0.4"
 getrandom = { version = "0.2", features = ["js"] }
 
 [dev-dependencies]
 serial_test = "2"
-tokio = { version = "1.28", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1.34", features = ["rt-multi-thread", "macros"] }
 
 [features]
 browser = []


### PR DESCRIPTION
```
    Checking coins-ledger v0.9.0
error[E0433]: failed to resolve: could not find `Builder` in `runtime`
  --> /home/doni/.cargo/registry/src/index.crates.io-6f17d22bba15001f/coins-ledger-0.9.0/src/transports/native/mod.rs:54:38
   |
54 |             let rt = tokio::runtime::Builder::new_current_thread()
   |                                      ^^^^^^^ could not find `Builder` in `runtime`
   |
help: consider importing this struct
   |
1  + use std::thread::Builder;
   |
help: if you import `Builder`, refer to it directly
   |
54 -             let rt = tokio::runtime::Builder::new_current_thread()
54 +             let rt = Builder::new_current_thread()
   |

error[E0603]: module `runtime` is private
   --> /home/doni/.cargo/registry/src/index.crates.io-6f17d22bba15001f/coins-ledger-0.9.0/src/transports/native/mod.rs:54:29
    |
54  |             let rt = tokio::runtime::Builder::new_current_thread()
    |                             ^^^^^^^ private module
    |
note: the module `runtime` is defined here
   --> /home/doni/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.34.0/src/lib.rs:523:5
    |
523 |     pub(crate) mod runtime;
    |     ^^^^^^^^^^^^^^^^^^^^^^
```